### PR TITLE
Support extra_model_paths.yaml for LLM folder configuration

### DIFF
--- a/AILab_QwenVL.py
+++ b/AILab_QwenVL.py
@@ -159,7 +159,13 @@ def ensure_model(model_name):
     if not info:
         raise ValueError(f"Model '{model_name}' not in config")
     repo_id = info["repo_id"]
-    models_dir = Path(folder_paths.models_dir) / "LLM" / "Qwen-VL"
+    # Use ComfyUI's multi-path system if available
+    llm_paths = folder_paths.get_folder_paths("LLM") if "LLM" in folder_paths.folder_names_and_paths else []
+    if llm_paths:
+        models_dir = Path(llm_paths[0]) / "Qwen-VL"
+    else:
+        # Fallback to default behavior
+        models_dir = Path(folder_paths.models_dir) / "LLM" / "Qwen-VL"
     models_dir.mkdir(parents=True, exist_ok=True)
     target = models_dir / repo_id.split("/")[-1]
     snapshot_download(


### PR DESCRIPTION
This change allows the node to respect ComfyUI's extra_model_paths.yaml configuration file when determining where to download Qwen-VL models.

Previously, models were always downloaded to the default ComfyUI models directory. Now, if a custom LLM path is defined in extra_model_paths.yaml, the node will use that location instead. This is particularly useful for:

- Users who want to centralize models across multiple ComfyUI installations
- Avoiding re-downloading models when reinstalling or updating ComfyUI
- Managing disk space by placing models on different drives

The change maintains backward compatibility by falling back to the original behavior if no custom LLM path is configured.