### PR TITLE
update pyproject.toml for python3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "ComfyUI-QwenVL"
 description = "ComfyUI-QwenVL custom node: Integrates the Qwen-VL series, including Qwen2.5-VL and the latest Qwen3-VL, with GGUF support for advanced multimodal AI in text generation, image understanding, and video analysis."
 version = "2.0.0"
-license = {file = "LICENSE"}
+license = "GPL-3.0-only"
+license-files = [ "LICENSE" ]
 dependencies = ["transformers", "torch", "huggingface-hub", "hf_xet", "psutil", "numpy", "Pillow", "opencv-python", "bitsandbytes", "accelerate"]
 
 [project.urls]
@@ -12,3 +13,6 @@ Repository = "https://github.com/1038lab/ComfyUI-QwenVL"
 PublisherId = "ailab"
 DisplayName = "ComfyUI-QwenVL"
 Icon = ""
+
+[tool.setuptools.packages]
+find = {}


### PR DESCRIPTION
from python 3.13 i wasn't able to "pip install ." until I made these changes.
see also
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
and
https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#custom-discovery