### PR TITLE
feat: support arbitrary HuggingFace models via custom repo ID

### DIFF
--- a/AILab_QwenVL.py
+++ b/AILab_QwenVL.py
@@ -70,6 +70,7 @@ TOOLTIPS = {
     "num_beams": "Beam-search width. Values >1 disable temperature/top_p and trade speed for more stable answers.",
     "repetition_penalty": "Values >1 (e.g., 1.1–1.3) penalize repeated phrases; 1.0 leaves logits untouched.",
     "frame_count": "Number of frames extracted from video inputs before prompting Qwen-VL. More frames provide context but cost time.",
+    "custom_model_repo": "Override model selection with a direct HuggingFace repo ID (e.g. Qwen/Qwen3-VL-4B-Instruct or myuser/my-finetune). Leave empty to use the dropdown above.",
 }
 
 class Quantization(str, Enum):
@@ -453,9 +454,13 @@ def set_sage_attention(model):
 
 def ensure_model(model_name):
     info = HF_ALL_MODELS.get(model_name)
-    if not info:
-        raise ValueError(f"Model '{model_name}' not in config")
-    repo_id = info["repo_id"]
+    if info:
+        repo_id = info["repo_id"]
+    elif "/" in model_name and len(model_name.split("/")) == 2:
+        repo_id = model_name
+        print(f"[QwenVL] Using custom HuggingFace repo: {repo_id}")
+    else:
+        raise ValueError(f"Model '{model_name}' not in config and not a valid HF repo ID (expected user/model format)")
 
     # Use ComfyUI's multi-path system if available
     llm_paths = folder_paths.get_folder_paths("LLM") if "LLM" in folder_paths.folder_names_and_paths else []
@@ -484,6 +489,8 @@ def ensure_model(model_name):
 def enforce_memory(model_name, quantization, device_info):
     info = HF_ALL_MODELS.get(model_name, {})
     requirements = info.get("vram_requirement", {})
+    if not requirements:
+        return quantization
     mapping = {
         Quantization.Q4: requirements.get("4bit", 0),
         Quantization.Q8: requirements.get("8bit", 0),
@@ -814,9 +821,11 @@ class QwenVLBase:
         text = self.tokenizer.decode(outputs[0, input_len:], skip_special_tokens=True)
         return text.strip()
 
-    def run(self, model_name, quantization, preset_prompt, custom_prompt, image, video, frame_count, max_tokens, temperature, top_p, num_beams, repetition_penalty, seed, keep_model_loaded, attention_mode, use_torch_compile, device):
+    def run(self, model_name, quantization, preset_prompt, custom_prompt, image, video, frame_count, max_tokens, temperature, top_p, num_beams, repetition_penalty, seed, keep_model_loaded, attention_mode, use_torch_compile, device, custom_model_repo=""):
         # Create progress bar with 3 stages: setup, model loading, generation
         pbar = ProgressBar(3)
+        
+        effective_model = custom_model_repo.strip() if custom_model_repo and custom_model_repo.strip() else model_name
         
         torch.manual_seed(seed)
         prompt = SYSTEM_PROMPTS.get(preset_prompt, preset_prompt)
@@ -826,7 +835,7 @@ class QwenVLBase:
         pbar.update_absolute(1, 3, None)
         
         self.load_model(
-            model_name,
+            effective_model,
             quantization,
             attention_mode,
             use_torch_compile,
@@ -874,6 +883,7 @@ class AILab_QwenVL(QwenVLBase):
                 "max_tokens": ("INT", {"default": 512, "min": 64, "max": 2048, "tooltip": TOOLTIPS["max_tokens"]}),
                 "keep_model_loaded": ("BOOLEAN", {"default": True, "tooltip": TOOLTIPS["keep_model_loaded"]}),
                 "seed": ("INT", {"default": 1, "min": 1, "max": 2**32 - 1, "tooltip": TOOLTIPS["seed"]}),
+                "custom_model_repo": ("STRING", {"default": "", "tooltip": TOOLTIPS["custom_model_repo"]}),
             },
             "optional": {
                 "image": ("IMAGE",),
@@ -886,8 +896,8 @@ class AILab_QwenVL(QwenVLBase):
     FUNCTION = "process"
     CATEGORY = "🧪AILab/QwenVL"
 
-    def process(self, model_name, quantization, preset_prompt, custom_prompt, attention_mode, max_tokens, keep_model_loaded, seed, image=None, video=None):
-        return self.run(model_name, quantization, preset_prompt, custom_prompt, image, video, 16, max_tokens, 0.6, 0.9, 1, 1.2, seed, keep_model_loaded, attention_mode, False, "auto")
+    def process(self, model_name, quantization, preset_prompt, custom_prompt, attention_mode, max_tokens, keep_model_loaded, seed, custom_model_repo="", image=None, video=None):
+        return self.run(model_name, quantization, preset_prompt, custom_prompt, image, video, 16, max_tokens, 0.6, 0.9, 1, 1.2, seed, keep_model_loaded, attention_mode, False, "auto", custom_model_repo=custom_model_repo)
 
 class AILab_QwenVL_Advanced(QwenVLBase):
     @classmethod
@@ -919,6 +929,7 @@ class AILab_QwenVL_Advanced(QwenVLBase):
                 "frame_count": ("INT", {"default": 16, "min": 1, "max": 64, "tooltip": TOOLTIPS["frame_count"]}),
                 "keep_model_loaded": ("BOOLEAN", {"default": True, "tooltip": TOOLTIPS["keep_model_loaded"]}),
                 "seed": ("INT", {"default": 1, "min": 1, "max": 2**32 - 1, "tooltip": TOOLTIPS["seed"]}),
+                "custom_model_repo": ("STRING", {"default": "", "tooltip": TOOLTIPS["custom_model_repo"]}),
             },
             "optional": {
                 "image": ("IMAGE",),
@@ -931,8 +942,8 @@ class AILab_QwenVL_Advanced(QwenVLBase):
     FUNCTION = "process"
     CATEGORY = "🧪AILab/QwenVL"
 
-    def process(self, model_name, quantization, attention_mode, use_torch_compile, device, preset_prompt, custom_prompt, max_tokens, temperature, top_p, num_beams, repetition_penalty, frame_count, keep_model_loaded, seed, image=None, video=None):
-        return self.run(model_name, quantization, preset_prompt, custom_prompt, image, video, frame_count, max_tokens, temperature, top_p, num_beams, repetition_penalty, seed, keep_model_loaded, attention_mode, use_torch_compile, device)
+    def process(self, model_name, quantization, attention_mode, use_torch_compile, device, preset_prompt, custom_prompt, max_tokens, temperature, top_p, num_beams, repetition_penalty, frame_count, keep_model_loaded, seed, custom_model_repo="", image=None, video=None):
+        return self.run(model_name, quantization, preset_prompt, custom_prompt, image, video, frame_count, max_tokens, temperature, top_p, num_beams, repetition_penalty, seed, keep_model_loaded, attention_mode, use_torch_compile, device, custom_model_repo=custom_model_repo)
 
 NODE_CLASS_MAPPINGS = {
     "AILab_QwenVL": AILab_QwenVL,

--- a/AILab_QwenVL_GGUF.py
+++ b/AILab_QwenVL_GGUF.py
@@ -333,47 +333,82 @@ class QwenVLGGUFBase:
         image_max_tokens: int | None,
         top_k: int | None,
         pool_size: int | None,
+        custom_repo_id: str = "",
+        custom_model_file: str = "",
+        custom_mmproj_file: str = "",
     ):
         self._load_backend()
 
-        resolved = _resolve_model_entry(model_name)
         base_dir = _resolve_base_dir(GGUF_VL_CATALOG.get("base_dir") or "llm/GGUF")
 
-        author_dir = _safe_dirname(resolved.author or "")
-        repo_dir = _safe_dirname(resolved.repo_dirname)
-        target_dir = base_dir / author_dir / repo_dir
+        if custom_repo_id and custom_model_file:
+            # Custom GGUF model: bypass catalog
+            parts = custom_repo_id.split("/")
+            author = _safe_dirname(parts[0]) if len(parts) >= 2 else "custom"
+            repo_name = _safe_dirname(parts[-1])
+            target_dir = base_dir / author / repo_name
 
-        model_path = target_dir / Path(resolved.model_filename).name
-        mmproj_path = target_dir / Path(resolved.mmproj_filename).name if resolved.mmproj_filename else None
+            model_path = target_dir / Path(custom_model_file).name
+            mmproj_path = target_dir / Path(custom_mmproj_file).name if custom_mmproj_file else None
 
-        repo_ids: list[str] = []
-        if resolved.repo_id:
-            repo_ids.append(resolved.repo_id)
-        repo_ids.extend(resolved.alt_repo_ids)
+            if not model_path.exists():
+                _download_single_file([custom_repo_id], custom_model_file, model_path)
+            if mmproj_path is not None and not mmproj_path.exists():
+                _download_single_file([custom_repo_id], custom_mmproj_file, mmproj_path)
 
-        if not model_path.exists():
-            if not repo_ids:
-                raise FileNotFoundError(f"[QwenVL] GGUF model not found locally and no repo_id provided: {model_path}")
-            _download_single_file(repo_ids, resolved.model_filename, model_path)
+            default_ctx = 8192
+            default_batch = 512
+            default_gpu_layers = -1
+            default_img_max = 4096
+            default_top_k = 0
+            default_pool_size = 4194304
 
-        if mmproj_path is not None and not mmproj_path.exists():
-            if not repo_ids:
-                raise FileNotFoundError(f"[QwenVL] mmproj not found locally and no repo_id provided: {mmproj_path}")
-            _download_single_file(repo_ids, resolved.mmproj_filename, mmproj_path)
+            print(f"[QwenVL] Using custom GGUF model from {custom_repo_id}")
+        else:
+            resolved = _resolve_model_entry(model_name)
+
+            author_dir = _safe_dirname(resolved.author or "")
+            repo_dir = _safe_dirname(resolved.repo_dirname)
+            target_dir = base_dir / author_dir / repo_dir
+
+            model_path = target_dir / Path(resolved.model_filename).name
+            mmproj_path = target_dir / Path(resolved.mmproj_filename).name if resolved.mmproj_filename else None
+
+            repo_ids: list[str] = []
+            if resolved.repo_id:
+                repo_ids.append(resolved.repo_id)
+            repo_ids.extend(resolved.alt_repo_ids)
+
+            if not model_path.exists():
+                if not repo_ids:
+                    raise FileNotFoundError(f"[QwenVL] GGUF model not found locally and no repo_id provided: {model_path}")
+                _download_single_file(repo_ids, resolved.model_filename, model_path)
+
+            if mmproj_path is not None and not mmproj_path.exists():
+                if not repo_ids:
+                    raise FileNotFoundError(f"[QwenVL] mmproj not found locally and no repo_id provided: {mmproj_path}")
+                _download_single_file(repo_ids, resolved.mmproj_filename, mmproj_path)
+
+            default_ctx = resolved.context_length
+            default_batch = resolved.n_batch
+            default_gpu_layers = resolved.gpu_layers
+            default_img_max = resolved.image_max_tokens
+            default_top_k = resolved.top_k
+            default_pool_size = resolved.pool_size
 
         device_kind = _pick_device(device)
 
-        n_ctx = int(ctx) if ctx is not None else resolved.context_length
-        n_batch_val = int(n_batch) if n_batch is not None else resolved.n_batch
-        top_k_val = int(top_k) if top_k is not None else resolved.top_k
-        pool_size_val = int(pool_size) if pool_size is not None else resolved.pool_size
+        n_ctx = int(ctx) if ctx is not None else default_ctx
+        n_batch_val = int(n_batch) if n_batch is not None else default_batch
+        top_k_val = int(top_k) if top_k is not None else default_top_k
+        pool_size_val = int(pool_size) if pool_size is not None else default_pool_size
 
         if device_kind == "cuda":
-            n_gpu_layers = int(gpu_layers) if gpu_layers is not None else resolved.gpu_layers
+            n_gpu_layers = int(gpu_layers) if gpu_layers is not None else default_gpu_layers
         else:
             n_gpu_layers = 0
 
-        img_max = int(image_max_tokens) if image_max_tokens is not None else resolved.image_max_tokens
+        img_max = int(image_max_tokens) if image_max_tokens is not None else default_img_max
 
         has_mmproj = mmproj_path is not None and mmproj_path.exists()
 
@@ -529,6 +564,9 @@ class QwenVLGGUFBase:
         image_max_tokens: int | None,
         top_k: int | None,
         pool_size: int | None,
+        custom_repo_id: str = "",
+        custom_model_file: str = "",
+        custom_mmproj_file: str = "",
     ):
         torch.manual_seed(int(seed))
 
@@ -557,6 +595,9 @@ class QwenVLGGUFBase:
                 image_max_tokens=image_max_tokens,
                 top_k=top_k,
                 pool_size=pool_size,
+                custom_repo_id=custom_repo_id,
+                custom_model_file=custom_model_file,
+                custom_mmproj_file=custom_mmproj_file,
             )
             if images_b64 and self.chat_handler is None:
                 print("[QwenVL] Warning: images provided but this model entry has no mmproj_file; images will be ignored")
@@ -598,6 +639,9 @@ class AILab_QwenVL_GGUF(QwenVLGGUFBase):
                 "max_tokens": ("INT", {"default": 512, "min": 64, "max": 2048}),
                 "keep_model_loaded": ("BOOLEAN", {"default": True}),
                 "seed": ("INT", {"default": 1, "min": 1, "max": 2**32 - 1}),
+                "custom_repo_id": ("STRING", {"default": "", "tooltip": "HuggingFace repo ID for a custom GGUF model (e.g. user/model-GGUF). Leave empty to use the dropdown above."}),
+                "custom_model_file": ("STRING", {"default": "", "tooltip": "Filename of the .gguf model file within the custom repo (e.g. model-Q4_K_M.gguf)."}),
+                "custom_mmproj_file": ("STRING", {"default": "", "tooltip": "Filename of the mmproj .gguf file for vision support (e.g. mmproj-model.gguf). Required for image/video input."}),
             },
             "optional": {
                 "image": ("IMAGE",),
@@ -618,6 +662,9 @@ class AILab_QwenVL_GGUF(QwenVLGGUFBase):
         max_tokens,
         keep_model_loaded,
         seed,
+        custom_repo_id="",
+        custom_model_file="",
+        custom_mmproj_file="",
         image=None,
         video=None,
     ):
@@ -641,6 +688,9 @@ class AILab_QwenVL_GGUF(QwenVLGGUFBase):
             image_max_tokens=None,
             top_k=None,
             pool_size=None,
+            custom_repo_id=custom_repo_id,
+            custom_model_file=custom_model_file,
+            custom_mmproj_file=custom_mmproj_file,
         )
 
 
@@ -678,6 +728,9 @@ class AILab_QwenVL_GGUF_Advanced(QwenVLGGUFBase):
                 "pool_size": ("INT", {"default": 4194304, "min": 1048576, "max": 10485760, "step": 524288}),
                 "keep_model_loaded": ("BOOLEAN", {"default": True}),
                 "seed": ("INT", {"default": 1, "min": 1, "max": 2**32 - 1}),
+                "custom_repo_id": ("STRING", {"default": "", "tooltip": "HuggingFace repo ID for a custom GGUF model (e.g. user/model-GGUF). Leave empty to use the dropdown above."}),
+                "custom_model_file": ("STRING", {"default": "", "tooltip": "Filename of the .gguf model file within the custom repo (e.g. model-Q4_K_M.gguf)."}),
+                "custom_mmproj_file": ("STRING", {"default": "", "tooltip": "Filename of the mmproj .gguf file for vision support (e.g. mmproj-model.gguf). Required for image/video input."}),
             },
             "optional": {
                 "image": ("IMAGE",),
@@ -709,6 +762,9 @@ class AILab_QwenVL_GGUF_Advanced(QwenVLGGUFBase):
         pool_size,
         keep_model_loaded,
         seed,
+        custom_repo_id="",
+        custom_model_file="",
+        custom_mmproj_file="",
         image=None,
         video=None,
     ):
@@ -732,6 +788,9 @@ class AILab_QwenVL_GGUF_Advanced(QwenVLGGUFBase):
             image_max_tokens=image_max_tokens,
             top_k=top_k,
             pool_size=pool_size,
+            custom_repo_id=custom_repo_id,
+            custom_model_file=custom_model_file,
+            custom_mmproj_file=custom_mmproj_file,
         )
 
 

--- a/AILab_QwenVL_GGUF_PromptEnhancer.py
+++ b/AILab_QwenVL_GGUF_PromptEnhancer.py
@@ -167,6 +167,8 @@ class AILab_QwenVL_GGUF_PromptEnhancer:
                 "english_output": ("BOOLEAN", {"default": False, "tooltip": "Force final output in English using translation prompt."}),
                 "device": (["auto", "cuda", "cpu", "mps"], {"default": "auto", "tooltip": "Select device; auto prefers GPU when available."}),
                 "seed": ("INT", {"default": 1, "min": 1, "max": 2**32 - 1}),
+                "custom_repo_id": ("STRING", {"default": "", "tooltip": "HuggingFace repo ID for a custom GGUF model (e.g. user/model-GGUF). Leave empty to use the dropdown above."}),
+                "custom_model_file": ("STRING", {"default": "", "tooltip": "Filename of the .gguf model file within the custom repo (e.g. model-Q4_K_M.gguf)."}),
             }
         }
 
@@ -262,11 +264,48 @@ class AILab_QwenVL_GGUF_PromptEnhancer:
         if not resolved.exists():
             raise FileNotFoundError(f"[QwenVL] GGUF model not found after download: {resolved} (tried: {', '.join(attempted)})")
 
-    def _load_model(self, model_name, device):
-        resolved = self._resolve_model_path(model_name)
-        self._maybe_download_model(model_name, resolved)
-        model_cfg = self.gguf_models["models"].get(model_name, {})
-        context_length = model_cfg.get("context_length", 8192)
+    def _load_model(self, model_name, device, custom_repo_id="", custom_model_file=""):
+        if custom_repo_id and custom_model_file:
+            # Custom GGUF model: bypass catalog
+            base_dir = _resolve_base_dir(self.gguf_models.get("base_dir") or "LLM/GGUF")
+            parts = custom_repo_id.split("/")
+            author = _safe_dirname(parts[0]) if len(parts) >= 2 else "custom"
+            repo_name = _safe_dirname(parts[-1])
+            target_dir = base_dir / author / repo_name
+
+            resolved = target_dir / Path(custom_model_file).name
+            if not resolved.exists():
+                resolved.parent.mkdir(parents=True, exist_ok=True)
+                # Download from HuggingFace
+                last_exc = None
+                for repo_id in [custom_repo_id]:
+                    print(f"[QwenVL] Downloading {custom_model_file} from {repo_id}")
+                    try:
+                        downloaded = hf_hub_download(
+                            repo_id=repo_id,
+                            filename=custom_model_file,
+                            repo_type="model",
+                            local_dir=str(target_dir),
+                            local_dir_use_symlinks=False,
+                        )
+                        downloaded_path = Path(downloaded)
+                        if downloaded_path.exists() and downloaded_path.resolve() != resolved.resolve():
+                            downloaded_path.replace(resolved)
+                        break
+                    except Exception as exc:
+                        last_exc = exc
+                        print(f"[QwenVL] Download failed from {repo_id}: {exc}")
+                if not resolved.exists():
+                    raise FileNotFoundError(f"[QwenVL] Custom GGUF model not found after download: {resolved} (error: {last_exc})")
+
+            context_length = 8192
+            print(f"[QwenVL] Using custom GGUF model from {custom_repo_id}")
+        else:
+            resolved = self._resolve_model_path(model_name)
+            self._maybe_download_model(model_name, resolved)
+            model_cfg = self.gguf_models["models"].get(model_name, {})
+            context_length = model_cfg.get("context_length", 8192)
+
         signature = (resolved, context_length, device)
         if self.llm is not None and self.current_signature == signature:
             return
@@ -368,6 +407,8 @@ class AILab_QwenVL_GGUF_PromptEnhancer:
         english_output,
         device,
         seed,
+        custom_repo_id="",
+        custom_model_file="",
     ):
         style_entry = self.styles.get(preset_system_prompt, {})
         system_prompt = (custom_system_prompt.strip() or style_entry.get("system_prompt") or "").strip()
@@ -380,7 +421,7 @@ class AILab_QwenVL_GGUF_PromptEnhancer:
         )
         user_prompt = prompt_text.strip() or "Describe a scene vividly."
         merged_prompt = user_prompt
-        self._load_model(model_name, device)
+        self._load_model(model_name, device, custom_repo_id=custom_repo_id, custom_model_file=custom_model_file)
         enhanced = self._invoke_llama(
             system_prompt=system_prompt,
             user_prompt=merged_prompt,

--- a/AILab_QwenVL_PromptEnhancer.py
+++ b/AILab_QwenVL_PromptEnhancer.py
@@ -93,6 +93,7 @@ class AILab_QwenVL_PromptEnhancer(QwenVLBase):
                 "repetition_penalty": ("FLOAT", {"default": 1.1, "min": 0.5, "max": 2.0}),
                 "keep_model_loaded": ("BOOLEAN", {"default": True}),
                 "seed": ("INT", {"default": 1, "min": 1, "max": 2**32 - 1}),
+                "custom_model_repo": ("STRING", {"default": "", "tooltip": "Override model selection with a direct HuggingFace repo ID (e.g. Qwen/Qwen3-4B). Leave empty to use the dropdown above. Custom repos are loaded as vision-language models; for text-only custom models, add them to custom_models.json."}),
             }
         }
 
@@ -112,16 +113,18 @@ class AILab_QwenVL_PromptEnhancer(QwenVLBase):
         repetition_penalty,
         keep_model_loaded,
         seed,
+        custom_model_repo="",
     ):
+        effective_model = custom_model_repo.strip() if custom_model_repo and custom_model_repo.strip() else model_name
         base_instruction = custom_system_prompt.strip() or self.STYLES.get(
             enhancement_style,
             next(iter(self.STYLES.values()), ""),
         )
         user_prompt = prompt_text.strip() or "Describe a scene vividly."
         merged_prompt = f"{base_instruction}\n\n{user_prompt}".strip()
-        if model_name in HF_TEXT_MODELS:
+        if not custom_model_repo.strip() and model_name in HF_TEXT_MODELS:
             enhanced = self._invoke_text(
-                model_name,
+                effective_model,
                 quantization,
                 device,
                 merged_prompt,
@@ -134,7 +137,7 @@ class AILab_QwenVL_PromptEnhancer(QwenVLBase):
             )
         else:
             enhanced = self._invoke_qwen(
-                model_name,
+                effective_model,
                 quantization,
                 attention_mode,
                 use_torch_compile,
@@ -189,7 +192,10 @@ class AILab_QwenVL_PromptEnhancer(QwenVLBase):
         info = HF_TEXT_MODELS.get(model_name, {})
         repo_id = info.get("repo_id")
         if not repo_id:
-            raise ValueError(f"[QwenVL] Missing repo_id for text model: {model_name}")
+            if "/" in model_name and len(model_name.split("/")) == 2:
+                repo_id = model_name
+            else:
+                raise ValueError(f"[QwenVL] Missing repo_id for text model: {model_name}")
 
         if device_choice == "auto":
             device = "cuda" if torch.cuda.is_available() else ("mps" if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available() else "cpu")


### PR DESCRIPTION
Add custom_model_repo input to all HF nodes (QwenVL, QwenVL Advanced, PromptEnhancer) allowing users to specify any HuggingFace repo ID (e.g. user/model-name) to override the predefined model dropdown.

Add custom_repo_id, custom_model_file, and custom_mmproj_file inputs to all GGUF nodes (QwenVL GGUF, QwenVL GGUF Advanced, GGUF Prompt Enhancer) for downloading and using arbitrary GGUF models from HF.

Key changes:
- ensure_model() accepts direct HF repo IDs (user/model format)
- enforce_memory() gracefully skips VRAM checks for unknown models
- GGUF _load_model() bypasses catalog when custom fields are provided
- PromptEnhancer _load_text_model() handles direct repo IDs
- All changes are backward-compatible (empty fields use dropdown)