### PR TITLE
fix: Prompt Enhancer text models ignore instructions (missing chat template)

### DIFF
--- a/AILab_QwenVL_PromptEnhancer.py
+++ b/AILab_QwenVL_PromptEnhancer.py
@@ -249,7 +249,19 @@ class AILab_QwenVL_PromptEnhancer(QwenVLBase):
         else:
             device_choice = device
 
-        inputs = self.text_tokenizer(prompt, return_tensors="pt").to(device_choice)
+        if getattr(self.text_tokenizer, "chat_template", None):
+            # Instruct models must be prompted through their chat template, otherwise
+            # they treat the prompt as a document to continue (echoing the instructions,
+            # drifting into unrelated text) instead of answering it.
+            encoded = self.text_tokenizer.apply_chat_template(
+                [{"role": "user", "content": prompt}],
+                add_generation_prompt=True,
+                return_tensors="pt",
+                return_dict=True,
+            )
+            inputs = {k: v.to(device_choice) for k, v in encoded.items()}
+        else:
+            inputs = self.text_tokenizer(prompt, return_tensors="pt").to(device_choice)
         kwargs = {
             "max_new_tokens": max_tokens,
             "repetition_penalty": repetition_penalty,
@@ -260,9 +272,8 @@ class AILab_QwenVL_PromptEnhancer(QwenVLBase):
             "pad_token_id": self.text_tokenizer.eos_token_id,
         }
         outputs = self.text_model.generate(**inputs, **kwargs)
-        decoded = self.text_tokenizer.decode(outputs[0], skip_special_tokens=True)
-        prefix = self.text_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-        result = decoded[len(prefix) :].strip()
+        prompt_len = inputs["input_ids"].shape[1]
+        result = self.text_tokenizer.decode(outputs[0][prompt_len:], skip_special_tokens=True).strip()
 
         if not keep_model_loaded:
             self.text_model = None


### PR DESCRIPTION
## Problem

In `AILab_QwenVL_PromptEnhancer.py`, `_invoke_text()` feeds the prompt to instruct text models (e.g. `Qwen3-4B-Instruct-2507`) as a raw string:

```python
inputs = self.text_tokenizer(prompt, return_tensors="pt").to(device_choice)
```

Without the chat template, an instruct model doesn't see an instruction/answer boundary — it treats the whole prompt as a document to *continue*. In practice the output:
- echoes fragments of the system instruction back,
- drifts into unrelated continuations (e.g. spontaneously starting "Write a short story about..."),
- ignores output-format rules from `custom_system_prompt`.

Reproduced with `Qwen3-4B-Instruct-2507` on transformers 5.8.0: with a strict "merge two captions" system prompt, the raw-completion path produced instruction echoes and runaway text; the exact same prompt through the chat template followed every rule cleanly.

## Fix

When the tokenizer has a `chat_template`, wrap the merged prompt as a user message via `apply_chat_template(add_generation_prompt=True, return_dict=True)` (dict form — in transformers 5.x it returns a `BatchEncoding`), and decode only the generated continuation by token offset instead of string-prefix slicing. Tokenizers without a chat template keep the old path.

Tested locally on Windows / RTX 5090 / torch 2.10.0+cu130 / transformers 5.8.0 with `Qwen3-4B-Instruct-2507` (BF16): instruction-following is night-and-day better, no echoes, clean stop after the answer.